### PR TITLE
Message and channel status page + other edits

### DIFF
--- a/docs/pages/using-nhs-notify/mesh.md
+++ b/docs/pages/using-nhs-notify/mesh.md
@@ -12,9 +12,10 @@ section: Accessing NHS Notify
 
 NHS England organisations and services can use the [Message Exchange for Social care and Health (MESH)](https://digital.nhs.uk/services/message-exchange-for-social-care-and-health-mesh) to send messages with NHS Notify.
 
-You should only use MESH to send messages if your organisation or service does not:
+You should only use MESH to send messages if your organisation or service:
 
-- have a developer
-- need the features offered by our API
+- has limited developer or technical capacity
+- only needs to send batches of messages to specific groups of recipients
+- does not need advanced features offered by NHS Notify API
 
 Check if MESH is right for you by contacting our engagement team at <england.nhsnotify@nhs.net>.

--- a/docs/pages/using-nhs-notify/message-status.md
+++ b/docs/pages/using-nhs-notify/message-status.md
@@ -1,0 +1,130 @@
+---
+# Feel free to add content and custom Front Matter to this file.
+# To modify the layout, see https://jekyllrb.com/docs/themes/#overriding-theme-defaults
+
+layout: page
+title: Message and channel status
+parent: Using NHS Notify
+nav_order: 7
+permalink: /using-nhs-notify/message-and-channel-status
+section: Sending a message
+---
+
+You can find out what's happened to your messages and channels by checking the message or channel status.
+
+To get an overall status of a message you've sent using a routing plan, use the [message status](#message-status).
+
+To see the status of a specific channel in your routing plan, use the [channel status](#channel-status).
+
+{% include components/details.html
+heading='If you’re using NHS Notify API'
+text='
+
+Check the status of a single message or channel by using the [get message status endpoint](https://digital.nhs.uk/developer/api-catalogue/nhs-notify#get-/v1/messages/-messageId-).
+
+To check the status of multiple messages automatically, use [message status callbacks](https://digital.nhs.uk/developer/api-catalogue/nhs-notify#post-/%3Cclient-provided-message-status-URI%3E).'
+%}
+
+{% include components/details.html
+heading='If you’re using NHS Notify MESH'
+text='
+
+You’ll receive a daily report of messages and channels that have completed that day.'
+
+%}
+
+## Message status
+
+| Status             | Description                                                                                                               |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------- |
+| created            | The message has been created but has not been processed by NHS Notify.                                                    |
+| pending_enrichment | NHS Notify is waiting to check and improve the recipient's contact details using the Personal Demographics Service (PDS). |
+| enriched           | NHS Notify has found the recipient's contact details.                                                                     |
+| sending            | The message is in the process of being sent.                                                                              |
+| delivered          | The message has been successfully delivered.                                                                              |
+| failed             | We have failed to deliver the message.                                                                                    |
+
+### Failed messages
+
+Messages and channels that have not reached a recipient will have a 'failed' status with one of the following descriptions:
+
+| Failed message status descriptions                                               |
+| -------------------------------------------------------------------------------- |
+| The provider could not deliver the message.                                      |
+| There was an unexpected error while sending the letter to our printing provider. |
+| PDS - patient record invalidated.                                                |
+| PDS response date of birth does not match given date of birth.                   |
+| PDS - patient is formally dead.                                                  |
+| PDS - patient is informally dead.                                                |
+| PDS - patient has exit an code.                                                  |
+| PDS - contact detail is malformed.                                               |
+| PDS - patient does not exist.                                                    |
+
+## Channel status
+
+There are specific statuses for each message channel:
+
+- [NHS App status descriptions](#nhs-app-message-status-descriptions) <!-- markdownlint-disable-line -->
+- [Email status descriptions](#email-status-descriptions)
+- [Text message status descriptions](#text-message-status-descriptions)
+- [Letter status descriptions](#letter-status-descriptions)
+
+### NHS App message status descriptions
+
+| Status                 | Description                                                                                                                      |
+| ---------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| received               | The supplier received the request to send an NHS App message.                                                                    |
+| created                | The NHS App message has been created.                                                                                            |
+| skipped                | The NHS App message has been skipped.                                                                                            |
+| sending                | The NHS App message is in the process of being sent.                                                                             |
+| delivered              | The NHS App message was successfully delivered.                                                                                  |
+| read                   | The recipient has opened the NHS App message.                                                                                    |
+| notified               | A push notification was sent and displayed on the recipient's device.                                                            |
+| notification attempted | A push notification has been sent to the recipient's device but we cannot confirm if the notification was received or displayed. |
+| unnotified             | A push notification was not sent or displayed on the recipient's device.                                                         |
+| rejected               | The supplier rejected the request to send the NHS App message.                                                                   |
+| failed                 | [Read more about failed messages descriptions](#failed-messages).                                                                |
+
+### Email status descriptions
+
+| Status            | Description                                                                                                                                  |
+| ----------------- | -------------------------------------------------------------------------------------------------------------------------------------------- |
+| created           | The NHS App message has been created.                                                                                                        |
+| skipped           | The NHS App message has been skipped.                                                                                                        |
+| sending           | The NHS App message is in the process of being sent.                                                                                         |
+| delivered         | The NHS App message was successfully delivered.                                                                                              |
+| failed            | [Read more about failed messages descriptions](#failed-messages).                                                                            |
+| permanent_failure | The provider could not deliver the message because the email address was wrong.                                                              |
+| temporary_failure | The provider could not deliver the message. This can happen when the recipient’s inbox is full or their anti-spam filter rejects your email. |
+| technical_failure | Your message was not sent because there was a problem between NHS Notify and the provider.                                                   |
+
+### Text message status descriptions
+
+| Status            | Description                                                                                                                                                                    |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| created           | The text message has been created.                                                                                                                                             |
+| skipped           | The text message has been skipped.                                                                                                                                             |
+| sending           | The text message is in the process of being sent.                                                                                                                              |
+| delivered         | The text message was successfully delivered.                                                                                                                                   |
+| failed            | [Read more about failed messages descriptions](#failed-messages).                                                                                                              |
+| permanent_failure | The provider could not deliver the message. This can happen if the phone number was wrong or if the network operator rejects the message                                       |
+| temporary_failure | The provider could not deliver the message. This can happen when the recipient’s phone is off, has no signal, or their text message inbox is full.                             |
+| technical_failure | Your message was not sent because there was a problem between NHS Notify and the provider. You will not be charged for text messages that are affected by a technical failure. |
+
+### Letter status descriptions
+
+| Status              | Description                                                                                                                                                         |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| created             | The text message has been created.                                                                                                                                  |
+| accepted            | NHS Notify has sent the letter to the provider to be printed.                                                                                                       |
+| skipped             | The letter has been skipped.                                                                                                                                        |
+| sending             | The letter is in the process of being sent.                                                                                                                         |
+| received            | The provider has printed and dispatched the letter.                                                                                                                 |
+| delivered           | The letter was successfully delivered.                                                                                                                              |
+| pending_virus_check | The provider has not yet completed a virus scan of the letter.                                                                                                      |
+| cancelled           | Sending cancelled. The letter will not be printed or dispatched.                                                                                                    |
+| failed              | [Read more about failed messages descriptions](#failed-messages).                                                                                                   |
+| virus_scan_failed   | The provider has found a potential virus in the precompiled letter file.                                                                                            |
+| validation_failed   | Content in the letter file is outside the printable area.                                                                                                           |
+| technical_failure   | NHS Notify had an unexpected error while sending the letter to our printing provider. You will not be charged for letters that are affected by a technical failure. |
+| permanent_failure   | The provider cannot print the letter. Your letter will not be dispatched.                                                                                           |

--- a/docs/pages/using-nhs-notify/tell-recipients-who-your-messages-are-from.md
+++ b/docs/pages/using-nhs-notify/tell-recipients-who-your-messages-are-from.md
@@ -14,27 +14,27 @@ It’s important that your recipients know and trust who has sent them a message
 
 You can change the:
 
-- [NHS App sender ID](#nhs-app-sender-id)<!-- markdownlint-disable-line -->
-- [text message sender ID](#text-message-sender-id)
+- [NHS App sender name](#nhs-app-sender-name)<!-- markdownlint-disable-line -->
+- [text message sender name](#text-message-sender-name)
 - [reply-to email address](#reply-to-email-address)
 
 ## Return addresses
 
 You cannot change the return addresses of letters. These are set by NHS Notify’s suppliers and are printed on the envelopes.
 
-## NHS App sender ID
+## NHS App sender name
 
-The NHS App uses your service or organisation’s ODS code to set up your NHS App message sender ID.
+The NHS App uses your service or organisation’s ODS code to set up your NHS App message sender name.
 
 NHS Notify will ask you for your ODS code during onboarding.
 
 Find your ODS code with the [ODS Portal](https://odsportal.digital.nhs.uk/).
 
-## Text message sender ID
+## Text message sender name
 
-You can set your text message sender ID during onboarding.
+You can set your text message sender name during onboarding.
 
-If you need to set up a different text message sender ID for another batch of messages, contact our onboarding team.
+If you need to set up a different text message sender name for another batch of messages, contact our onboarding team.
 
 ## Reply-to email address
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- created new page **/using-nhs-notify/message-and-channel-status**
- changed /using-nhs-notify/mesh to match MESH guidance on Confluence
- sender IDs changed to sender names

## Context

FAQs captured by onboarding showed that users ask a lot of questions about what happens to messages and what sort of message statuses they can expect to see. 

There is an opportunity to host all the message and channel statuses alongside reworded descriptions to improve user understanding of what happens to their messages when they are sent using NHS Notify.

Centralising message statuses and their descriptions means that users of NHS Notify API or NHS Notify MESH have access to the same information.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
