### PR TITLE
Letter delivery times update + anchor links

### DIFF
--- a/docs/pages/using-nhs-notify/delivery-times.md
+++ b/docs/pages/using-nhs-notify/delivery-times.md
@@ -12,6 +12,13 @@ section: Sending a message
 
 It can take different amounts of time for messages to be delivered depending on the message channel.
 
+Find out about delivery times for:
+
+- [NHS App messages](#nhs-app-messages)<!-- markdownlint-disable-line -->
+- [emails](#emails)
+- [text messages](#text-messages-sms)
+- [letters](#letters)
+
 ## NHS App messages
 
 NHS Notify can send NHS App messages to recipients with the NHS App at any time.
@@ -42,7 +49,7 @@ NHS Notify will only send text messages from 8am to 6pm on weekdays.
 
 ## Letters
 
-Once your letter has been sent, it can take up to 6 days for it to be processed by our suppliers before it's dispatched.
+Once you've [provided us with recipients' NHS numbers]({% link pages/using-nhs-notify/tell-us-who-you-want-to-message.md %}), it can take up to 2 working days for our suppliers to dispatch your letter.
 
 First class letters are delivered 1 to 2 business days after they’re dispatched.
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

In /using-nhs-notify/delivery-times#letters, I replaced the sentence beginning 'Once your letter has been sent, it can take...' with 'Once you've provided us with recipients' NHS numbers, it can take up to 2 working days for our suppliers to dispatch your letter'.

I also added anchor links to the top of the same page, /using-nhs-notify/delivery-times, to make navigation easier.

## Context

Had a meeting with Gaby Kenton recently and she let me know that the old sentence about letter processing times wasn't accurate. The [Confluence page table](https://nhsd-confluence.digital.nhs.uk/display/RIS/3.5+Delivery+times) shows the changes.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
