### PR TITLE
PDS personalisation fields updates + main nav wrapping

### DIFF
--- a/docs/_sass/_nhsnotify.scss
+++ b/docs/_sass/_nhsnotify.scss
@@ -69,6 +69,7 @@
 
 .nhsuk-header__navigation-list {
   justify-content: flex-start;
+  flex-wrap: wrap;
 }
 
 .nhsuk-header__navigation-link {

--- a/docs/pages/using-nhs-notify/personalisation.md
+++ b/docs/pages/using-nhs-notify/personalisation.md
@@ -20,9 +20,9 @@ To personalise a message, use double brackets to add a placeholder to your conte
 
 ### Personal Demographics Service (PDS) personalisation fields
 
-NHS Notify uses the [Personal Demographics Service (PDS)](https://digital.nhs.uk/services/personal-demographics-service) to find and populate certain personalisation fields. You only need to [provide us with recipients' NHS numbers]({% link pages/using-nhs-notify/tell-us-who-you-want-to-message.md %}).
+NHS Notify uses the [Personal Demographics Service (PDS)](https://digital.nhs.uk/services/personal-demographics-service) to find and populate certain personalisation fields for each recipient. This happens automatically when you [tell us who you want to message]({% link pages/using-nhs-notify/tell-us-who-you-want-to-message.md %}) using recipients' NHS numbers.
 
-The personalisation fields available in PDS are:
+You can use the following PDS personalisation fields in your templates:
 
 - fullName
 - firstName
@@ -30,20 +30,10 @@ The personalisation fields available in PDS are:
 - lastName
 - namePrefix
 - nameSuffix
-- address_line_1
-- address_line_2
-- address_line_3
-- address_line_4
-- address_line_5
-- address_line_6
-- address_line_7
 - nhsNumber
 - date
-- clientRef
-- recipientContactValue
-- template
 
-The placeholders in your content need to match the PDS personalisation fields.
+Any placeholders in your content need to match the PDS personalisation fields.
 
 ## Providing your own personalisation data
 
@@ -58,7 +48,7 @@ Include a personalisation block in your API request.
 For example, if you wanted to include 'practice' as a personalisation field, the personalisation block would be:
 
 {% include components/inset-text.html
-    text='{
+text='{
 
     "practice": "PRACTICE_NAME",
 
@@ -71,7 +61,7 @@ Read the [API documentation](https://digital.nhs.uk/developer/api-catalogue/nhs-
 
 Include the personalisation fields as columns in your CSV file.
 
-The column names should start with 'personalisation_', followed by the same wording as the placeholders in your template.
+The column names should start with 'personalisation\_', followed by the same wording as the placeholders in your template.
 
 For example, if you wanted to include 'practice' as a personalisation field, the column name would be:
 
@@ -79,5 +69,5 @@ For example, if you wanted to include 'practice' as a personalisation field, the
     text='nhsNumber,requestItemRefId,dateOfBirth,personalisation_practice'
 %}
 
-*[PDS]: Personal Demographics Service
-*[MESH]: Message Exchange for Social Care and Health
+_[PDS]: Personal Demographics Service
+_[MESH]: Message Exchange for Social Care and Health


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description
This PR includes 3 changes:

1. In /using-nhs-notify/personalisation, I removed address_line_x, clientRef, recipientContactValue and template from the bulleted list of personalisation fields from PDS. These fields are for internal use only or would not make sense when inserted into a message template. I agreed this approach with Alex Nuttall.

2. In /using-nhs-notify/personalisation, I restructured the first paragraph under ### Personal Demographics Service (PDS) personalisation fields. This was based off a conversation with Jake. The content change aims to clarify the link between PDS, NHS numbers and personalisation fields.

3. In /workspaces/nhs-notify-web-cms-dev/docs/_sass/_nhsnotify.scss I added the line 'flex-wrap: wrap;' to the following block of code:
.nhsuk-header__navigation-list {
justify-content: flex-start;
flex-wrap: wrap;
}
This is an interim step to make the main nav list items wrap correctly when the site is viewed on a mobile device. It's not our ultimate solution but it makes our site more mobile responsive and accessible.

## Context

The context of each change is described in each numbered step above.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
