### PR TITLE
Removed mentions of Date of Birth

### DIFF
--- a/docs/pages/using-nhs-notify/mesh.md
+++ b/docs/pages/using-nhs-notify/mesh.md
@@ -18,4 +18,6 @@ You should only use MESH to send messages if your organisation or service:
 - only needs to send batches of messages to specific groups of recipients
 - does not need advanced features offered by NHS Notify API
 
+[Read our MESH documentation (opens in a new tab)](https://digital.nhs.uk/developer/api-catalogue/nhs-notify-mesh).
+
 Check if MESH is right for you by contacting our engagement team at <england.nhsnotify@nhs.net>.

--- a/docs/pages/using-nhs-notify/message-status.md
+++ b/docs/pages/using-nhs-notify/message-status.md
@@ -53,7 +53,6 @@ Messages and channels that have not reached a recipient will have a 'failed' sta
 | The provider could not deliver the message.                                      |
 | There was an unexpected error while sending the letter to our printing provider. |
 | PDS - patient record invalidated.                                                |
-| PDS response date of birth does not match given date of birth.                   |
 | PDS - patient is formally dead.                                                  |
 | PDS - patient is informally dead.                                                |
 | PDS - patient has an exit code.                                                  |

--- a/docs/pages/using-nhs-notify/personalisation.md
+++ b/docs/pages/using-nhs-notify/personalisation.md
@@ -41,7 +41,7 @@ You can provide your own personalisation data.
 
 Do not send us personalisation data that's already available in PDS. We'll use the PDS data over your own data in this case.
 
-### If you're using the API
+### If you're using NHS Notify API
 
 Include a personalisation block in your API request.
 
@@ -57,7 +57,7 @@ text='{
 
 Read the [API documentation](https://digital.nhs.uk/developer/api-catalogue/nhs-notify#post-/v1/message-batches) to find out where to put this in your request.
 
-### If you're using the Message Exchange for Social Care and Health (MESH)
+### If you're using NHS Notify MESH
 
 Include the personalisation fields as columns in your CSV file.
 
@@ -66,8 +66,5 @@ The column names should start with 'personalisation\_', followed by the same wor
 For example, if you wanted to include 'practice' as a personalisation field, the column name would be:
 
 {% include components/inset-text.html
-    text='nhsNumber,requestItemRefId,dateOfBirth,personalisation_practice'
+    text='nhsNumber,requestItemRefId,personalisation_practice'
 %}
-
-_[PDS]: Personal Demographics Service
-_[MESH]: Message Exchange for Social Care and Health

--- a/docs/pages/using-nhs-notify/personalisation.md
+++ b/docs/pages/using-nhs-notify/personalisation.md
@@ -18,7 +18,7 @@ To personalise a message, use double brackets to add a placeholder to your conte
     text='<code>Hello ((firstName)), your NHS Number is ((nhsNumber))'
 %}
 
-### Personal Demographics Service (PDS) personalisation fields
+## Personal Demographics Service (PDS) personalisation fields
 
 NHS Notify uses the [Personal Demographics Service (PDS)](https://digital.nhs.uk/services/personal-demographics-service) to find and populate certain personalisation fields for each recipient. This happens automatically when you [tell us who you want to message]({% link pages/using-nhs-notify/tell-us-who-you-want-to-message.md %}) using recipients' NHS numbers.
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This is part of [CCM-7683](https://nhsd-jira.digital.nhs.uk/browse/CCM-7683)

**Changes:**

- /message-and-channel-status > removed failed message description related to a date of birth not matching
- /personalisation > removed 'dateOfBirth' as an example of a column header you can include in a MESH request

## Context

A decision has been made to remove the Date of Birth validation field from NHS Notify.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
